### PR TITLE
Fixed bug with detecting if a Market Filter toggle was active. 

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -246,7 +246,7 @@ function loadFeedItems(prevFeedItemCount, numItems) {
 
 function setMarketFilter(selector, active) {
   var classes = casper.getElementAttribute(selector, "class");
-  var isMarketActive = classes.split(" ").indexOf("active") == 0;
+  var isMarketActive = classes.split(" ").indexOf("active") != -1;
   if (isMarketActive != active) {
     casper.click(selector);
     casper.wait(1000);


### PR DESCRIPTION
To determine if the toggle was enabled, the code was checking to see if an "active" class was among all classes for the selector at index 0. However, I found the "active" tag can, and often is, placed as the last class for the selector (index 2), so I switch the to instead check for lack of "active" tag (index -1).