### PR TITLE
Refactored numFeedItems to not use jQuery

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -29,11 +29,12 @@ class FeedParser(object):
             writer = csv.writer(csvfile)
 
             for feed_item_html in self.get_feed_items():
-                try:
-                    item = self.extract_feed_item_fields(feed_item_html)
-                    writer.writerow([item[field_name] for field_name in fields_to_write])
-                except:
-                    print("Something wrong happened writing data")
+                if 'empty-item' not in feed_item_html.attrs['class']:
+                    try:
+                        item = self.extract_feed_item_fields(feed_item_html)
+                        writer.writerow([item[field_name] for field_name in fields_to_write])
+                    except:
+                        print("Something wrong happened writing data")
     
     def extract_feed_item_fields(self, feed_item_html):
         result = {}

--- a/scrape.js
+++ b/scrape.js
@@ -214,7 +214,7 @@ function clickDesignerFilter(designer) {
 
 function numFeedItems() {
   return casper.evaluate(function () {
-    return document.querySelectorAll("div.feed-item").length;
+    return document.querySelectorAll("div.feed-item:not(.empty-item)").length;
   });
 }
 

--- a/scrape.js
+++ b/scrape.js
@@ -214,7 +214,7 @@ function clickDesignerFilter(designer) {
 
 function numFeedItems() {
   return casper.evaluate(function () {
-    return $("div.feed-item").length;
+    return document.querySelectorAll("div.feed-item").length;
   });
 }
 


### PR DESCRIPTION
Refactored code to avoid using jquery to evaluate the number of items scraped as jQuery requires additional setup beyond the boilerplate casperjs build and beyond what is described in the README.

Additionally, I added additional logic to filter out the placeholder item divs from both the counting function and parsing script, as there are usually three at the end of the feed which were being counted and causing errors in the parsing.