### PR TITLE
Updated sizes panel selectors to match latest website schema

### DIFF
--- a/grailedSelectors.js
+++ b/grailedSelectors.js
@@ -173,7 +173,7 @@ exports.GrailedSelectors = function() {
   self.sizes = {
     tops: {
       panel:
-        ".sizes-wrapper > div.filter-bottom.checkboxes > span:nth-child(1) > div > h3 > span:nth-child(1)",
+        ".sizes-wrapper > div.-collapsible-content > div.filter-bottom.checkboxes > span:nth-child(1) > div > h3 > span:nth-child(1)",
       XXS:
         ".sizes-wrapper .sizes.tops.outerwear > p.active-indicator:nth-of-type(1)",
       XS:
@@ -191,7 +191,7 @@ exports.GrailedSelectors = function() {
     },
     bottoms: {
       panel:
-        ".sizes-wrapper > div.filter-bottom.checkboxes > span:nth-child(2) > div > h3 > span:nth-child(1)",
+        ".sizes-wrapper > div.-collapsible-content > div.filter-bottom.checkboxes > span:nth-child(2) > div > h3 > span:nth-child(1)",
       26: ".sizes-wrapper .sizes.bottoms > p.active-indicator:nth-of-type(1)",
       27: ".sizes-wrapper .sizes.bottoms > p.active-indicator:nth-of-type(2)",
       28: ".sizes-wrapper .sizes.bottoms > p.active-indicator:nth-of-type(3)",
@@ -214,7 +214,7 @@ exports.GrailedSelectors = function() {
     },
     footwear: {
       panel:
-        ".sizes-wrapper > div.filter-bottom.checkboxes > span:nth-child(3) > div > h3 > span:nth-child(1)",
+        ".sizes-wrapper > div.-collapsible-content > div.filter-bottom.checkboxes > span:nth-child(3) > div > h3 > span:nth-child(1)",
       "5": ".sizes-wrapper .sizes.footwear > p.active-indicator:nth-of-type(1)",
       "5.5":
         ".sizes-wrapper .sizes.footwear > p.active-indicator:nth-of-type(2)",
@@ -251,7 +251,7 @@ exports.GrailedSelectors = function() {
     },
     tailoring: {
       panel:
-        ".sizes-wrapper > div.filter-bottom.checkboxes > span:nth-child(4) > div > h3 > span:nth-child(1)",
+        ".sizes-wrapper > div.-collapsible-content > div.filter-bottom.checkboxes > span:nth-child(4) > div > h3 > span:nth-child(1)",
       "34S":
         ".sizes-wrapper .sizes.tailoring > p.active-indicator:nth-of-type(1)",
       "34R":
@@ -315,7 +315,7 @@ exports.GrailedSelectors = function() {
     },
     accessories: {
       panel:
-        ".sizes-wrapper > div.filter-bottom.checkboxes > span:nth-child(5) > div > h3 > span:nth-child(1)",
+        ".sizes-wrapper > div.-collapsible-content > div.filter-bottom.checkboxes > span:nth-child(5) > div > h3 > span:nth-child(1)",
       OS:
         ".sizes-wrapper .sizes.accessories > p.active-indicator:nth-of-type(1)",
       26: ".sizes-wrapper .sizes.accessories > p.active-indicator:nth-of-type(2)",


### PR DESCRIPTION
Grailed website seems to have changed their HTML DOM tree slightly. I've update the sizes panel selectors to match the latest DOM schema.