### PR TITLE
Fixed bug when using --configFile flag to load filters from json file

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -40,6 +40,7 @@ casper.then(function () {
   if (casper.cli.has('configFile')) {
     var obj = casper.cli.get("configFile");
     var data = JSON.parse(fs.read(obj));
+    filter.add(data)
     console.log(JSON.stringify(data));
   }
 })


### PR DESCRIPTION
When using the `--configFile` flag, the filter wasn't actually being leveraged by code. Added a line to add the contents of the json file into the filter object.